### PR TITLE
Add Linux build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: build
+run-name: build
+on: [push]
+jobs:
+  build:
+    name: build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Build
+        run: |
+            # Install JUCE Linux dependencies
+            sudo apt update
+            sudo apt install libasound2-dev libjack-jackd2-dev \
+                ladspa-sdk \
+                libcurl4-openssl-dev  \
+                libfreetype-dev libfontconfig1-dev \
+                libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev \
+                libwebkit2gtk-4.0-dev \
+                libglu1-mesa-dev mesa-common-dev
+
+            # Use clang as the compiler
+            sudo apt install clang
+            export CXX=clang++
+            export CC=clang
+
+            # Build Projucer
+            git clone --depth=1 -b 8.0.4 https://github.com/juce-framework/JUCE.git ~/JUCE
+            cd ~/JUCE/extras/Projucer/Builds/LinuxMakefile/
+            make -j4
+            cd -
+
+            # Build Wilsonic
+            ~/JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave Wilsonic.jucer
+            cd Builds/LinuxMakefile
+            make -j4 CONFIG=Release
+            cd -
+            mkdir upload
+            cp -r Builds/LinuxMakefile/build/Wilsonic.vst3 upload
+            cp Builds/LinuxMakefile/build/Wilsonic upload
+
+            # Build WilsonicController
+            rm -r Builds
+            ~/JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave WilsonicController.jucer
+            cd Builds/LinuxMakefile
+            make -j4 CONFIG=Release
+            cd -
+            cp -r Builds/LinuxMakefile/build/WilsonicController.vst3 upload
+            cp Builds/LinuxMakefile/build/WilsonicController upload
+
+
+      - uses: actions/upload-artifact@v4
+        with:
+            name: Wilsonic_${{ matrix.os }}_${{ github.sha }}
+            path: upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             export CC=clang
 
             # Build Projucer
-            git clone --depth=1 -b 8.0.4 https://github.com/juce-framework/JUCE.git ~/JUCE
+            git clone --depth=1 -b 7.0.11 https://github.com/juce-framework/JUCE.git ~/JUCE
             cd ~/JUCE/extras/Projucer/Builds/LinuxMakefile/
             make -j4
             cd -


### PR DESCRIPTION
I had a go at setting up the Linux build to run in CI. On each push this workflow builds Wilsonic and WilsonicController and uploads the built plugins and standalones to the actions page for the build.

The build runs on an older version of Ubuntu (20.04) to produce fairly widely compatible binaries; I thought this might be useful in case at some point you would be interested in adding Linux builds to the releases. I've tested the Wilsonic and WilsonicController VST3 plugins built in CI on my laptop (running Arch Linux) and they work as expected.

Of course I completely understand if you already have other plans for CI and would prefer not to merge this! I got curious about setting it up and figured once I had a branch I may as well make a PR.