### PR TITLE
Add simple math tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,10 @@ jobs:
             cp -r Builds/LinuxMakefile/build/WilsonicController.vst3 upload
             cp Builds/LinuxMakefile/build/WilsonicController upload
 
+            # build and run unit tests
+            make -C tests
+            ./tests/test_wilsonicmath
+
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -346,3 +346,4 @@ symbolicate_crash.py
 symbolicate.command
 windows_installer_64.iss
 Wilsonic-MTS-ESP_installer/
+tests/test_wilsonicmath

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Wilsonic MTS-ESP is an advanced audio plugin and standalone application for crea
 
 5. The built standalone application and plugins will be in the "Builds" directory.
 
+## Running Tests
+
+Compile and execute the unit tests with:
+
+```bash
+make -C tests
+./tests/test_wilsonicmath
+```
+
 ## Usage
 
 Refer to the [User Manual](https://drive.google.com/file/d/1BrTWlS9N4a0xTRUzwLxwr5R5JJ2RvF8n) for detailed instructions on how to use Wilsonic.

--- a/tests/JuceHeader.h
+++ b/tests/JuceHeader.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <cassert>
+#include <cmath>
+#include <limits>
+
+#ifndef jassert
+#define jassert(x) assert(x)
+#endif
+
+template <typename Type>
+static constexpr const Type& jlimit(const Type& lower, const Type& upper, const Type& value)
+{
+    return value < lower ? lower : (value > upper ? upper : value);
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,11 @@
+CXX = g++
+CXXFLAGS = -std=c++17 -I../Source -I. -Wall -Wextra
+TARGET = test_wilsonicmath
+
+all: $(TARGET)
+
+$(TARGET): test_wilsonicmath.cpp ../Source/WilsonicMath.cpp
+	$(CXX) $(CXXFLAGS) $^ -o $@
+
+clean:
+	rm -f $(TARGET)

--- a/tests/test_wilsonicmath.cpp
+++ b/tests/test_wilsonicmath.cpp
@@ -1,0 +1,36 @@
+#include <cassert>
+#include <cmath>
+
+#ifndef jassert
+#define jassert(x) assert(x)
+#endif
+
+template <typename Type>
+static Type jlimit(Type lower, Type upper, Type value)
+{
+    return value < lower ? lower : (value > upper ? upper : value);
+}
+
+#include "../Source/WilsonicMath.h"
+
+int main() {
+    using WM = WilsonicMath;
+
+    // linear interpolation clamps fraction to [0,1]
+    assert(WM::linearInterp(0.0f, 10.0f, 0.5f) == 5.0f);
+    assert(WM::linearInterp(0.0f, 10.0f, -1.0f) == 0.0f);
+    assert(WM::linearInterp(0.0f, 10.0f, 2.0f) == 10.0f);
+
+    // smoothstep should return 0 at edge0 and 1 at edge1
+    assert(WM::smoothstep(0.0f, 1.0f, 0.0f) == 0.0f);
+    assert(WM::smoothstep(0.0f, 1.0f, 1.0f) == 1.0f);
+
+    float mid = WM::smoothstep(0.0f, 1.0f, 0.5f);
+    assert(std::fabs(mid - 0.5f) <= WM::getEpsilon(WM::Epsilon::CALC));
+
+    // floating point comparisons
+    assert(WM::floatsAreEqual(0.1f, 0.1f));
+    assert(WM::floatsAreNotEqual(0.1f, 0.1002f, WM::Epsilon::UI));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a minimal unit test for WilsonicMath
- provide a stub JuceHeader so tests build without JUCE
- integrate test build into GitHub workflow
- document how to run tests
- ignore generated test binary

## Testing
- `make -C tests`
- `./tests/test_wilsonicmath`
